### PR TITLE
Mount "/Library/Internet Plug-Ins" for darwin_native

### DIFF
--- a/modules/darwin_native.subr
+++ b/modules/darwin_native.subr
@@ -79,7 +79,6 @@ _darwin_native_bindfs_mounts() {
                 Graphics) ;;
                 Image\ Capture) ;;
                 Input\ Methods) ;;
-                Internet\ Plug-Ins) ;;
                 Keyboard\ Layouts) ;;
                 Keychains) ;;
                 LaunchAgents) ;;


### PR DESCRIPTION
Mounting `/Library/Internet Plug-Ins` in the sandbox for the `darwin_native` sandbox type allows `lang/oracle-jre8` to be detected as a built-in since the Oracle JRE is installed under that tree.  Without it, `lang/oracle-jre8` fails to detect a built-in version, tries to build, and fails on fetching the distribution file because it must be downloaded by hand along with accepting the license.